### PR TITLE
CI: build binaries for linux and macOS

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -66,4 +66,4 @@
 ^\Q.github/workflows/spelling.yml\E$
 ^\Qbin/.placeholder\E$
 ignore$
-^\.github/actions/
+^\.github/workflows/

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -66,3 +66,4 @@
 ^\Q.github/workflows/spelling.yml\E$
 ^\Qbin/.placeholder\E$
 ignore$
+^\.github/actions/

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,0 +1,61 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build_linux:
+    # TODO: see if we can cross compile for other archs with CGo
+    runs-on: ubuntu-latest
+    name: Go build (Linux)
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.20'
+        check-latest: true
+
+    - name: Build (amd64)
+      run: GOOS=linux GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+    - name: Upload binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: lightningstream_linux_amd64.bin
+        path: bin/lightningstream
+
+  build_macos:
+    # We use one version older than the latest, to ensure compatibility
+    runs-on: macos-11
+    name: Go build (macOS)
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.20'
+        check-latest: true
+
+    - name: Build (amd64)
+      run: GOOS=darwin GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+    - name: Upload binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: lightningstream_darwin_amd64.bin
+        path: bin/lightningstream
+
+    - name: Build (arm64)
+      run: GOOS=darwin GOARCH=arm64 CGO_EMABLED=1 ./build.sh
+    - name: Upload binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: lightningstream_darwin_arm64.bin
+        path: bin/lightningstream
+

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -54,6 +54,8 @@ jobs:
       with:
         name: lightningstream_darwin_amd64.bin.gz
         path: bin/lightningstream.gz
+    - name: Cleanup
+      run: rm bin/lightningstream.gz
 
     - name: Build (arm64)
       run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 ./build.sh

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -25,11 +25,13 @@ jobs:
 
     - name: Build (amd64)
       run: GOOS=linux GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+    - name: Compress
+      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_linux_amd64.bin
-        path: bin/lightningstream
+        name: lightningstream_linux_amd64.bin.gz
+        path: bin/lightningstream.gz
 
   build_macos:
     # We use one version older than the latest, to ensure compatibility
@@ -45,17 +47,21 @@ jobs:
 
     - name: Build (amd64)
       run: GOOS=darwin GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+    - name: Compress
+      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_darwin_amd64.bin
-        path: bin/lightningstream
+        name: lightningstream_darwin_amd64.bin.gz
+        path: bin/lightningstream.gz
 
     - name: Build (arm64)
       run: GOOS=darwin GOARCH=arm64 CGO_EMABLED=1 ./build.sh
+    - name: Compress
+      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_darwin_arm64.bin
-        path: bin/lightningstream
+        name: lightningstream_darwin_arm64.bin.gz
+        path: bin/lightningstream.gz
 

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -5,15 +5,17 @@ name: Go Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
 
   build_linux:
     # TODO: see if we can cross compile for other archs with CGo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Go build (Linux)
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -25,13 +25,11 @@ jobs:
 
     - name: Build (amd64)
       run: GOOS=linux GOARCH=amd64 CGO_ENABLED=1 ./build.sh
-    - name: Compress
-      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_linux_amd64.bin.gz
-        path: bin/lightningstream.gz
+        name: lightningstream_linux_amd64.bin
+        path: bin/lightningstream
 
   build_macos:
     # We use one version older than the latest, to ensure compatibility
@@ -47,23 +45,17 @@ jobs:
 
     - name: Build (amd64)
       run: GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 ./build.sh
-    - name: Compress
-      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_darwin_amd64.bin.gz
-        path: bin/lightningstream.gz
-    - name: Cleanup
-      run: rm bin/lightningstream.gz
+        name: lightningstream_darwin_amd64.bin
+        path: bin/lightningstream
 
     - name: Build (arm64)
       run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 ./build.sh
-    - name: Compress
-      run: gzip bin/lightningstream
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:
-        name: lightningstream_darwin_arm64.bin.gz
-        path: bin/lightningstream.gz
+        name: lightningstream_darwin_arm64.bin
+        path: bin/lightningstream
 

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -24,7 +24,7 @@ jobs:
         check-latest: true
 
     - name: Build (amd64)
-      run: GOOS=linux GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+      run: GOOS=linux GOARCH=amd64 CGO_ENABLED=1 ./build.sh
     - name: Compress
       run: gzip bin/lightningstream
     - name: Upload binary
@@ -46,7 +46,7 @@ jobs:
         check-latest: true
 
     - name: Build (amd64)
-      run: GOOS=darwin GOARCH=amd64 CGO_EMABLED=1 ./build.sh
+      run: GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 ./build.sh
     - name: Compress
       run: gzip bin/lightningstream
     - name: Upload binary
@@ -56,7 +56,7 @@ jobs:
         path: bin/lightningstream.gz
 
     - name: Build (arm64)
-      run: GOOS=darwin GOARCH=arm64 CGO_EMABLED=1 ./build.sh
+      run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 ./build.sh
     - name: Compress
       run: gzip bin/lightningstream
     - name: Upload binary

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,17 +5,21 @@ name: Go Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: [ '1.20', '1.19' ]
+        go:
+          - '1.19'
+          - '1.20'
         
     name: Go ${{ matrix.go }} tests
     steps:

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,11 @@ fi
 
 for cmd in cmd/*; do
     if [ -d "$cmd" ]; then
-        echo "+ go install \"./$cmd\""
-        go install "./$cmd"
+        name=$(basename "$cmd")
+        # go install refuses to install cross-compiled binaries
+        # https://github.com/golang/go/issues/57485
+        echo "go build -o $GOBIN/$name  ./$cmd"
+        go build -o "$GOBIN/$name"  "./$cmd"
     fi
 done    
 


### PR DESCRIPTION
Checking if we can build binaries for Linux (amd64) and macOS (amd64 and arm64).

Since LS uses CGo for the LMDB bindings, cross compiling is more complicated. Perhaps we can use docker's support for running in qemu?

The macOS ones may be of limited value, because they are not signed. Running them may be more of a hassle than compiling them yourself for most users. Perhaps add to homebrew instead?


