### PR TITLE
Check spelling updates

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -12,7 +12,6 @@ ccc
 changeme
 commandline
 conseq
-crv
 customtype
 datasize
 dbi
@@ -59,7 +58,6 @@ gostring
 govet
 healthtracker
 healthz
-HOSTKEY
 htmltemplate
 Hugetlb
 idx
@@ -122,7 +120,6 @@ reslice
 REVERSEDUP
 REVERSEKEY
 samber
-schemaversion
 segfaults
 setmapsize
 setmaxdbs
@@ -167,7 +164,6 @@ wiretype
 wktpointer
 wojas
 WORKDIR
-workflows
 yml
 yyy
 zzz

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -1,4 +1,6 @@
-# reject `m_data` as there's a certain OS which has evil defines that break things if it's used elsewhere
+# reject `m_data` as VxWorks defined it and that breaks things if it's used elsewhere
+# see [fprime](https://github.com/nasa/fprime/commit/d589f0a25c59ea9a800d851ea84c2f5df02fb529)
+# and [Qt](https://github.com/qtproject/qt-solutions/blame/fb7bc42bfcc578ff3fa3b9ca21a41e96eb37c1c7/qtscriptclassic/src/qscriptbuffer_p.h#L46)
 # \bm_data\b
 
 # If you have a framework that uses `it()` for testing and `fit()` for debugging a specific test,

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -75,6 +75,10 @@ on:
 jobs:
   spelling:
     name: Check Spelling
+    # By default github permissions are quite generous. Best practices
+    # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#restricting-permissions-for-tokens
+    # are that each and every workflow/job define the maximum that it can possibly
+    # need (which should be much smaller, at least in range, than the defaults).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -93,7 +93,7 @@ jobs:
         suppress_push_for_open_pull_request: 1
         checkout: true
         check_file_names: 1
-        spell_check_this: check-spelling/spell-check-this@prerelease
+        spell_check_this: powerdns/lightningstream@main
         post_comment: 0
         use_magic_file: 1
         extra_dictionary_limit: 10


### PR DESCRIPTION
This is a bundle of fairly unrelated things.

Note that the commit messages for some of these changes are incredibly long.

The `m_data` comment update corresponds to this:
https://github.com/check-spelling/spell-check-this/commit/4f81233290253fc998a6ce3e9fe7b638d672dd86
@Habbie asked me if I knew where it came from, and at the time it was written, I didn't, it was just something that was mentioned by https://github.com/nasa/fprime as a thing they'd like to be able to handle (https://github.com/nasa/fprime/discussions/855). It turns out their repository actually did indicate which vendor had the issue (https://github.com/nasa/fprime/commit/aa4cb0006fd6d8abae086d521fb5fa70d9ee7f66), but I didn't check for that and merely noted it as a theoretical case. I've now updated the check-spelling wiki [entry](https://github.com/check-spelling/check-spelling/wiki/Feature%3A-Forbidden-patterns#forbidden-patterns) to provide more information about its pedigree.

The expect updates would be triggered the next time someone introduced a misspelling, but since I'm already making a PR, I'm bundling it here. (They're mostly the result of #44's changes which excluded checking the `.github/workflows` directory.) Fwiw, this is a conscious tradeoff. check-spelling aims for a form of "eventual consistency". It's more or less ok to temporarily have a couple of stray expected items as they'll be cleaned up the next time someone tries to add an unexpected word. If there's ever a case where you really don't want a word coming in, you can use the forbidden feature (as `m_data` could be -- see above).