### PR TITLE
Upgrade `simpleblob` to v0.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/CrowdStrike/csproto v0.23.1
 	github.com/PowerDNS/lmdb-go v1.9.0
-	github.com/PowerDNS/simpleblob v0.2.3
+	github.com/PowerDNS/simpleblob v0.2.4
 	github.com/bufbuild/buf v0.56.0
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df h1:WMUClevRP
 github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df/go.mod h1:aKP0MVHWl7U3ruSXqAmzsoVVFm8HhYIpOmm1MwkDyDY=
 github.com/PowerDNS/lmdb-go v1.9.0 h1:pvdI8lzdeAfWJdkXc3XPZXCewX508awqfe5yMjSKNTE=
 github.com/PowerDNS/lmdb-go v1.9.0/go.mod h1:5beHlX2aYqXfMBI0+BBX3LDhV3YGHU5JgoDsirAFPlA=
-github.com/PowerDNS/simpleblob v0.2.3 h1:Pc933mehEYm12ANcT80UFVUg6y4iqTBNoMvKEN6kb4Y=
-github.com/PowerDNS/simpleblob v0.2.3/go.mod h1:Ws1+vamCWSKtneoEPOl2MsGiGPpsf/DEtcP7C8/EcPw=
+github.com/PowerDNS/simpleblob v0.2.4 h1:kw4+b3Qr11MgYkq2jSn82XsPV/PjlVkkxA7ltb1u3D0=
+github.com/PowerDNS/simpleblob v0.2.4/go.mod h1:Ws1+vamCWSKtneoEPOl2MsGiGPpsf/DEtcP7C8/EcPw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
`simpleblob@v0.2.4` introduces two bug fixes for the S3 backend.

Closes #55 #57 

From the [release page](https://github.com/PowerDNS/simpleblob/releases/tag/v0.2.4):

> 
> This fixes a resource leak that can cause growing memory and CPU usage over time (https://github.com/PowerDNS/simpleblob/issues/44) for all S3 users.
> 
> It also fixes the update marker not working when a global S3 prefix is used, which causes simpleblob to use more expensive LIST API calls, leading to increased S3 usage costs.
> What's Changed
> 
>     S3 backend: fix resource leak due to missing Close for GetObject by @ahouene in https://github.com/PowerDNS/simpleblob/pull/45 (fixes https://github.com/PowerDNS/simpleblob/issues/44)
>     Fix global prefix not working with update marker by @ahouene in https://github.com/PowerDNS/simpleblob/pull/42 (fixes https://github.com/PowerDNS/simpleblob/issues/40)