### PR TITLE
simpleblob to v0.2.6 (and run go mod tidy)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ Currently available options:
 | init_timeout | duration | Time allowed for initialisation (default: "20s") |
 | use_update_marker | bool | Reduce LIST commands, see link below |
 | update_marker_force_list_interval | duration | See link below for details |
-| disable_send_content_md5 | bool | Disble sending Content-MD5 header |
+| disable_send_content_md5 | bool | Disable sending Content-MD5 header |
 
 The `use_update_marker` option can reduce your AWS S3 bill in small personal
 deployments without compromises on update latency, as GET operations are 10 times cheaper

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,7 @@ Currently available options:
 | init_timeout | duration | Time allowed for initialisation (default: "20s") |
 | use_update_marker | bool | Reduce LIST commands, see link below |
 | update_marker_force_list_interval | duration | See link below for details |
+| disable_send_content_md5 | bool | Disble sending Content-MD5 header |
 
 The `use_update_marker` option can reduce your AWS S3 bill in small personal
 deployments without compromises on update latency, as GET operations are 10 times cheaper

--- a/docs/configuration.template.md
+++ b/docs/configuration.template.md
@@ -94,6 +94,7 @@ Currently available options:
 | init_timeout | duration | Time allowed for initialisation (default: "20s") |
 | use_update_marker | bool | Reduce LIST commands, see link below |
 | update_marker_force_list_interval | duration | See link below for details |
+| disable_send_content_md5 | bool | Disble sending Content-MD5 header |
 
 The `use_update_marker` option can reduce your AWS S3 bill in small personal
 deployments without compromises on update latency, as GET operations are 10 times cheaper

--- a/docs/configuration.template.md
+++ b/docs/configuration.template.md
@@ -94,7 +94,7 @@ Currently available options:
 | init_timeout | duration | Time allowed for initialisation (default: "20s") |
 | use_update_marker | bool | Reduce LIST commands, see link below |
 | update_marker_force_list_interval | duration | See link below for details |
-| disable_send_content_md5 | bool | Disble sending Content-MD5 header |
+| disable_send_content_md5 | bool | Disable sending Content-MD5 header |
 
 The `use_update_marker` option can reduce your AWS S3 bill in small personal
 deployments without compromises on update latency, as GET operations are 10 times cheaper

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/CrowdStrike/csproto v0.23.1
 	github.com/PowerDNS/lmdb-go v1.9.0
-	github.com/PowerDNS/simpleblob v0.2.5
+	github.com/PowerDNS/simpleblob v0.2.6
 	github.com/bufbuild/buf v0.56.0
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df h1:WMUClevRP
 github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df/go.mod h1:aKP0MVHWl7U3ruSXqAmzsoVVFm8HhYIpOmm1MwkDyDY=
 github.com/PowerDNS/lmdb-go v1.9.0 h1:pvdI8lzdeAfWJdkXc3XPZXCewX508awqfe5yMjSKNTE=
 github.com/PowerDNS/lmdb-go v1.9.0/go.mod h1:5beHlX2aYqXfMBI0+BBX3LDhV3YGHU5JgoDsirAFPlA=
-github.com/PowerDNS/simpleblob v0.2.5 h1:JI3pGI8KyzDXDL75ae5QPCw5588X6z6/nBzehiCe2TE=
-github.com/PowerDNS/simpleblob v0.2.5/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
+github.com/PowerDNS/simpleblob v0.2.6 h1:rTBL0ecM8j9bf9jPXx6bxnzeBn3oK8WfAPqGL9WX3eE=
+github.com/PowerDNS/simpleblob v0.2.6/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
- simpleblob to v0.2.6
- add table row in docs for new md5 option
- run `go mod tidy`
Introduces use of Content-MD5 header in S3 uploads in order to ensure end-to-end integrity.
See #65