### PR TITLE
S3 snapshot metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/PowerDNS/simpleblob v0.2.5 => github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/CrowdStrike/csproto v0.23.1
 	github.com/PowerDNS/lmdb-go v1.9.0
-	github.com/PowerDNS/simpleblob v0.2.5
+	github.com/PowerDNS/simpleblob v0.2.7
 	github.com/bufbuild/buf v0.56.0
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/gogo/protobuf v1.3.2
@@ -71,5 +71,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/PowerDNS/simpleblob v0.2.5 => github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df h1:WMUClevRP
 github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df/go.mod h1:aKP0MVHWl7U3ruSXqAmzsoVVFm8HhYIpOmm1MwkDyDY=
 github.com/PowerDNS/lmdb-go v1.9.0 h1:pvdI8lzdeAfWJdkXc3XPZXCewX508awqfe5yMjSKNTE=
 github.com/PowerDNS/lmdb-go v1.9.0/go.mod h1:5beHlX2aYqXfMBI0+BBX3LDhV3YGHU5JgoDsirAFPlA=
-github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb h1:8nC/gzbnYj+Fru/+vbQjY0YQQNwYkuex7QKbMQhhTY4=
-github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
+github.com/PowerDNS/simpleblob v0.2.7 h1:eslNYitaaaOgIqZdYWnMH1nJIc6HApIvBs63zzKBYQE=
+github.com/PowerDNS/simpleblob v0.2.7/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df h1:WMUClevRP
 github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df/go.mod h1:aKP0MVHWl7U3ruSXqAmzsoVVFm8HhYIpOmm1MwkDyDY=
 github.com/PowerDNS/lmdb-go v1.9.0 h1:pvdI8lzdeAfWJdkXc3XPZXCewX508awqfe5yMjSKNTE=
 github.com/PowerDNS/lmdb-go v1.9.0/go.mod h1:5beHlX2aYqXfMBI0+BBX3LDhV3YGHU5JgoDsirAFPlA=
-github.com/PowerDNS/simpleblob v0.2.5 h1:JI3pGI8KyzDXDL75ae5QPCw5588X6z6/nBzehiCe2TE=
-github.com/PowerDNS/simpleblob v0.2.5/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
+github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb h1:8nC/gzbnYj+Fru/+vbQjY0YQQNwYkuex7QKbMQhhTY4=
+github.com/PowerDNS/simpleblob v0.2.7-0.20240222075823-2d5a347a5aeb/go.mod h1:demorqIrYIbxW3wsU5SS5NufPyGseDW+xofeQZw4w3o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/syncer/receiver/metrics.go
+++ b/syncer/receiver/metrics.go
@@ -65,14 +65,14 @@ var (
 	)
 	metricSnapshotsStorageCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "lightningstream_receiver_snapshots_count_in_storage",
+			Name: "lightningstream_receiver_snapshots_in_storage_count",
 			Help: "Number of snapshots in storage",
 		},
 		[]string{"lmdb"},
 	)
 	metricSnapshotsStorageBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "lightningstream_receiver_snapshots_bytes_in_storage",
+			Name: "lightningstream_receiver_snapshots_in_storage_bytes",
 			Help: "Number of bytes occupied by snapshots in storage",
 		},
 		[]string{"lmdb"},

--- a/syncer/receiver/metrics.go
+++ b/syncer/receiver/metrics.go
@@ -63,7 +63,20 @@ var (
 			Help: "Number of bytes downloaded successfully",
 		},
 	)
-	// TODO: add total space used by all snapshots
+	metricSnapshotsStorageCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lightningstream_receiver_snapshots_count_in_storage",
+			Help: "Number of snapshots in storage",
+		},
+		[]string{"lmdb"},
+	)
+	metricSnapshotsStorageBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lightningstream_receiver_snapshots_last_bytes_in_storage",
+			Help: "Number of bytes occupied by snapshots in storage",
+		},
+		[]string{"lmdb"},
+	)
 )
 
 func init() {
@@ -74,4 +87,6 @@ func init() {
 	prometheus.MustRegister(metricSnapshotsLoadFailed)
 	prometheus.MustRegister(metricSnapshotsListFailed)
 	prometheus.MustRegister(metricSnapshotsLoadBytes)
+	prometheus.MustRegister(metricSnapshotsStorageCount)
+	prometheus.MustRegister(metricSnapshotsStorageBytes)
 }

--- a/syncer/receiver/metrics.go
+++ b/syncer/receiver/metrics.go
@@ -72,7 +72,7 @@ var (
 	)
 	metricSnapshotsStorageBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "lightningstream_receiver_snapshots_last_bytes_in_storage",
+			Name: "lightningstream_receiver_snapshots_bytes_in_storage",
 			Help: "Number of bytes occupied by snapshots in storage",
 		},
 		[]string{"lmdb"},

--- a/syncer/receiver/receiver.go
+++ b/syncer/receiver/receiver.go
@@ -164,6 +164,9 @@ func (r *Receiver) RunOnce(ctx context.Context, includingOwn bool) error {
 		return fmt.Errorf("list snapshots: %w", err)
 	}
 
+	// Update snapshot metrics
+	metricSnapshotsStorageCount.WithLabelValues(r.lmdbname).Set(float64(ls.Len()))
+
 	// Signal success to health tracker
 	r.storageListHealth.AddSuccess()
 

--- a/syncer/receiver/receiver.go
+++ b/syncer/receiver/receiver.go
@@ -166,6 +166,7 @@ func (r *Receiver) RunOnce(ctx context.Context, includingOwn bool) error {
 
 	// Update snapshot metrics
 	metricSnapshotsStorageCount.WithLabelValues(r.lmdbname).Set(float64(ls.Len()))
+	metricSnapshotsStorageBytes.WithLabelValues(r.lmdbname).Set(float64(ls.Size()))
 
 	// Signal success to health tracker
 	r.storageListHealth.AddSuccess()


### PR DESCRIPTION
This PR includes:
- 2 new metrics on receiver for number of snapshots in storage and cumulative size of them
- Simpleblob upgrade to 0.2.7 to make use of BlobList's new `Size()` function

This allows for monitoring of s3 storage usage for each LMDB.