### PR TITLE
Add Minio to github actions to use in test suite

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,5 +30,12 @@ jobs:
         go-version: ${{ matrix.go }}
     - name: Build
       run: go build -v ./...
+    - name: Start MinIO (emulates S3)
+      run: |
+        wget -q https://dl.min.io/server/minio/release/linux-amd64/minio
+        chmod +x minio
+        export MINIO_ROOT_USER=minioadmin
+        export MINIO_ROOT_PASSWORD=minioadmin
+        ./minio server /tmp/minio --address 127.0.0.1:4730 --quiet &
     - name: Test
       run: ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -3,10 +3,10 @@
 if [ ! -z "$SIMPLEBLOB_TEST_S3_CONFIG" ]; then
     echo "* Using existing SIMPLEBLOB_TEST_S3_CONFIG=$SIMPLEBLOB_TEST_S3_CONFIG"
 elif curl -v --connect-timeout 2 http://localhost:4730/ 2>&1 | grep --silent MinIO ; then
-    echo "* Using MinIO in Docker Compose for tests"
+    echo "* Using MinIO on localhost for tests"
     export SIMPLEBLOB_TEST_S3_CONFIG="$PWD/docker/test-minio.json"
 else
-    echo "* MinIO not running in Docker Compose, skipping S3 tests"
+    echo "* MinIO not running on localhost, skipping S3 tests"
 fi
 
 set -ex


### PR DESCRIPTION
Closes PowerDNS/lightningstream#36

I took the liberty to add a Minio to the go workflow so test can be ran against it in the CI.
I also changed the wording in the test.sh to reflect that it runs against a Minio on localhost.