### PR TITLE
Upgrade to Go 1.24 & CI fixes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -43,7 +43,7 @@ jobs:
       - run: mv site lightningstream-html-docs
       - run: tar cf lightningstream-html-docs.tar lightningstream-html-docs
       
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lightningstream-html-docs-${{steps.get-version.outputs.ls_version}}
           path: ./lightningstream-html-docs.tar

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-upload-docs:
     name: Build and upload docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -35,7 +35,7 @@ jobs:
 
   build_macos:
     # We use one version older than the latest, to ensure compatibility
-    runs-on: macos-11
+    runs-on: macos-15
     name: Go build (macOS)
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.24'
         check-latest: true
 
     - name: Build (amd64)
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.24'
         check-latest: true
 
     - name: Build (amd64)

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -15,7 +15,7 @@ jobs:
 
   build_linux:
     # TODO: see if we can cross compile for other archs with CGo
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Go build (Linux)
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-22.04
     name: Go build (Linux)
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: '1.24'
         check-latest: true
@@ -28,7 +28,7 @@ jobs:
     - name: Build (amd64)
       run: GOOS=linux GOARCH=amd64 CGO_ENABLED=1 ./build.sh
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lightningstream_linux_amd64.bin
         path: bin/lightningstream
@@ -38,9 +38,9 @@ jobs:
     runs-on: macos-11
     name: Go build (macOS)
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: '1.24'
         check-latest: true
@@ -48,7 +48,7 @@ jobs:
     - name: Build (amd64)
       run: GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 ./build.sh
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lightningstream_darwin_amd64.bin
         path: bin/lightningstream
@@ -56,7 +56,7 @@ jobs:
     - name: Build (arm64)
       run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 ./build.sh
     - name: Upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lightningstream_darwin_arm64.bin
         path: bin/lightningstream

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.19'
-          - '1.20'
+          - '1.24'
         
     name: Go ${{ matrix.go }} tests
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,9 +22,9 @@ jobs:
         
     name: Go ${{ matrix.go }} tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
     - name: Build

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -111,3 +111,4 @@ jobs:
           cspell:python/src/common/extra.txt
           cspell:npm/npm.txt
         check_extra_dictionaries: ''
+

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.21
+      uses: check-spelling/check-spelling@v0.0.24
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,62 @@
-# See https://github.com/golangci/golangci-lint/blob/master/.golangci.yml for more examples
+version: "2"
 
 linters:
-    enabled:
-        # In addition to default standard linters (see: golangci-lint help linters)
-        # Try extra ones line this: golangci-lint run --disable-all --enable=lll
-        - goimports
-        # For future consideration (requires some extra work, but suggestions look useful)
-        # - gocritic
-        # - golint # can sometimes be a bit pedantic
-        # - lll
-
-run:
-    skip-files: []
-
-linters-settings:
+  settings:
     govet:
-        # settings per analyzer
-        settings:
-            printf: # analyzer name, run `go tool vet help` to see all analyzers
-                funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-                    - (*github.com/sirupsen/logrus.Entry).Debugf
-                    - (*github.com/sirupsen/logrus.Entry).Infof
-                    - (*github.com/sirupsen/logrus.Entry).Logf
-                    - (*github.com/sirupsen/logrus.Entry).Warnf
-                    - (*github.com/sirupsen/logrus.Entry).Errorf
-                    - (*github.com/sirupsen/logrus.Entry).Fatalf
-                    - github.com/sirupsen/logrus.Debugf
-                    - github.com/sirupsen/logrus.Infof
-                    - github.com/sirupsen/logrus.Logf
-                    - github.com/sirupsen/logrus.Warnf
-                    - github.com/sirupsen/logrus.Errorf
-                    - github.com/sirupsen/logrus.Fatalf
+      settings:
+        printf:
+          funcs:
+            - (*github.com/sirupsen/logrus.Entry).Debugf
+            - (*github.com/sirupsen/logrus.Entry).Infof
+            - (*github.com/sirupsen/logrus.Entry).Logf
+            - (*github.com/sirupsen/logrus.Entry).Warnf
+            - (*github.com/sirupsen/logrus.Entry).Errorf
+            - (*github.com/sirupsen/logrus.Entry).Fatalf
+            - github.com/sirupsen/logrus.Debugf
+            - github.com/sirupsen/logrus.Infof
+            - github.com/sirupsen/logrus.Logf
+            - github.com/sirupsen/logrus.Warnf
+            - github.com/sirupsen/logrus.Errorf
+            - github.com/sirupsen/logrus.Fatalf
+    staticcheck:
+      checks:
+        - "all"
+        # excluded by default
+        #- "-ST1000"
+        #- "-ST1003" 
+        #- "-ST1016"
+        #- "-ST1020"
+        #- "-ST1021"
+        #- "-ST1022"
+        # Allow `createIsSet := false` initialization for clarity
+        - "-QF1007"
 
-issues:
-    exclude-rules:
-        # Ignore complaints about using lmdbenv.KVString without labels in tests
-        - path: _test\.go
-          text: lmdbenv.KVString struct literal uses unkeyed fields
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        text: lmdbenv.KVString struct literal uses unkeyed fields
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - powerdns.com
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builder
 # Note: Not using Alpine, because of CGo deps
-FROM golang:1.24-bookworm as builder
+FROM golang:1.24-bookworm AS builder
 ENV GOBIN=/usr/local/bin
 ARG GOPROXY=
 
@@ -21,7 +21,7 @@ RUN echo "GOFLAGS=$GOFLAGS"; go install ./cmd/...
 # Note: When using Alpine, ls prevents auth api from correctly functioning (most likely some locking issue)
 # Reason: When you have multiple processing accessing the same LMDB, they MUST use the same libc, otherwise
 #         way file locking is done will conflict.
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN ulimit -n 2000 \
         && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Builder
 # Note: Not using Alpine, because of CGo deps
-FROM golang:1.19-buster as builder
+FROM golang:1.24-bookworm as builder
 ENV GOBIN=/usr/local/bin
 ARG GOPROXY=
 
 # GOFLAGS workaround for Go 1.19 when building from subrepos
 # Issue: https://github.com/golang/go/issues/53640
+# TODO: Check if still needed for 1.24+
 ARG GOFLAGS
 ENV GOFLAGS ${GOFLAGS}
 
@@ -18,6 +19,8 @@ RUN echo "GOFLAGS=$GOFLAGS"; go install ./cmd/...
 
 # Dist
 # Note: When using Alpine, ls prevents auth api from correctly functioning (most likely some locking issue)
+# Reason: When you have multiple processing accessing the same LMDB, they MUST use the same libc, otherwise
+#         way file locking is done will conflict.
 FROM debian:buster-slim
 
 RUN ulimit -n 2000 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             - "minio:/data" 
 
     auth1:
-        image: powerdns/pdns-auth-48
+        image: powerdns/pdns-auth-49
         environment:
             instance: 1
             port: 53
@@ -40,7 +40,7 @@ services:
         entrypoint: /run.sh
     
     auth2:
-        image: powerdns/pdns-auth-48
+        image: powerdns/pdns-auth-49
         environment:
             instance: 2
             port: 53
@@ -57,7 +57,7 @@ services:
         entrypoint: /run.sh
 
     auth3:
-        image: powerdns/pdns-auth-48
+        image: powerdns/pdns-auth-49
         environment:
             instance: 3
             port: 53

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PowerDNS/lightningstream
 
-go 1.19
+go 1.24
 
 require (
 	github.com/CrowdStrike/csproto v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -309,6 +310,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -355,6 +357,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -773,6 +776,7 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -933,6 +937,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/lmdbenv/strategy/append.go
+++ b/lmdbenv/strategy/append.go
@@ -19,7 +19,6 @@ import (
 // - Sorted input
 //
 // Uses: make the very first snapshot load fast.
-//
 func Append(txn *lmdb.Txn, dbi lmdb.DBI, it Iterator) error {
 	prevKey := make([]byte, 0, LMDBMaxKeySize)
 	for {

--- a/status/httpd.go
+++ b/status/httpd.go
@@ -177,6 +177,6 @@ func (p *Page) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := statusTemplate.Execute(w, data)
 	if err != nil {
 		w.WriteHeader(500)
-		_, _ = w.Write([]byte(fmt.Sprintf("Template execution error: %v", err)))
+		_, _ = fmt.Fprintf(w, "Template execution error: %v", err)
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,6 @@ GOMAXPROCS=1 go test -race -count=5 "$@" ./...
 go test -count 20 -run TestSyncer_Sync_startup ./syncer
 
 # Configure linters in .golangci.yml
-GOBIN="$PWD/bin" go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
+GOBIN="$PWD/bin" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
 ./bin/golangci-lint run
 


### PR DESCRIPTION
- Upgrade to Go 1.24
- Upgrade to golangci-lint v2 with required config changes and lint fixes
- Upgrade Docker Debian image from buster to bookworm
- Upgrade from Auth 4.8 to 4.9

Temporarily disabled the Spelling CI step through the Action web interface, because it kept using the old version. I suspect that it can be reenabled after merging this PR.
