### PR TITLE
Tombsweeper: clean stale delete markers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -244,6 +244,7 @@ type Sweeper struct {
 	// LockDuration limits how long the sweeper may hold the exclusive write
 	// lock at one time. This effectively controls the maximum latency spike
 	// due to the sweeper for API calls that update the LMDB.
+	// This is not a hard quota, the sweeper may overrun it slightly.
 	// Default: 50ms
 	LockDuration time.Duration `yaml:"lock_duration"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -259,6 +259,10 @@ type Sweeper struct {
 	ReleaseDuration time.Duration `yaml:"release_duration"`
 }
 
+func (sw Sweeper) RetentionDuration() time.Duration {
+	return time.Duration(sw.RetentionDays * float32(24*time.Hour))
+}
+
 type DBIOptions struct {
 	// OverrideCreateFlags can override DBI create flags when loading a
 	// snapshot and the DBI does not create yet.

--- a/config/config.go
+++ b/config/config.go
@@ -283,7 +283,7 @@ func (sw Sweeper) RetentionDurationMinusCutoff() time.Duration {
 		if buffer > maxBuffer {
 			buffer = maxBuffer
 		}
-		retention -= sw.RetentionLoadCutoffDuration // override in config
+		retention -= buffer // override in config
 	} else {
 		retention -= retention / 100 // subtract default 1%
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -210,10 +210,10 @@ type LMDB struct {
 // When picking a value, also take into account development, testing and
 // migration systems that only occasionally come online.
 //
-// TODO: Consider if we want to write a marker to keep track of the last
-//       sync, and reject sync once we have passed this interval.
-//       This would be the first instance of retained LS state. Up until now
-//       LS operates in a stateless way.
+//	     TODO: Consider if we want to write a marker to keep track of the last
+//			   sync, and reject sync once we have passed this interval.
+//			   This would be the first instance of retained LS state. Up until
+//			   now LS operates in a stateless way.
 type Sweeper struct {
 	// Enabled controls if the sweeper is enabled.
 	// It is DISABLED by default, because of the important consistency

--- a/docker/pdns/lightningstream.yaml
+++ b/docker/pdns/lightningstream.yaml
@@ -13,6 +13,17 @@ lmdbs:
       no_subdir: true
       create: true
 
+sweeper:
+  # We want to run in the devenv, but we do not want anything to be
+  # actually cleaned, because we do not have the right consistency
+  # guarantees here. The devenv is expected to only be spun up occasionally.
+  enabled: true
+  retention_days: 3650  # 10 years
+  interval: 6h
+  first_interval: 1m
+  lock_duration: 50ms
+  release_duration: 50ms
+
 storage:
   #type: fs
   type: s3

--- a/example.yaml
+++ b/example.yaml
@@ -161,6 +161,64 @@ lmdbs:
     #  records:
     #    override_create_flags: 0
 
+
+# Sweeper settings for the LMDB sweeper that removed deleted entries after
+# a while, also known as the "tomb sweeper".
+#
+# The key consideration for these settings is how long instance can be
+# expected to be disconnected from the storage (out of sync) before
+# rejoining. If the retention interval is set too low, old records that
+# have been removed during the downtime can reappear, which can cause
+# major issues.
+#
+# When picking a value, also take into account development, testing and
+# migration systems that only occasionally come online.
+#
+sweeper:
+  # Enabled controls if the sweeper is enabled.
+  # It is DISABLED by default, because of the important consistency
+  # considerations that depend on the kind of deployment.
+  # When disabled, the deleted entries will never actually be removed.
+  #enabled: false
+  
+  # RetentionDays is the number of DAYS of retention. Unlike in most
+  # other places, this is specified in number of days instead of Duration
+  # because of the expected length of this.
+  # This is a float, so it is possible to use periods shorter than one day,
+  # but this is rarely a good idea. Best to set this as high as possible.
+  # Default: 370 (days, intentionally on the safe side)
+  #retention_days: 370
+  
+  # Interval is the interval between sweeps of the whole database to enforce
+  # RetentionDays.
+  # As a guideline, on a fast server sweeping 1 million records takes
+  # about 1 second.
+  # Default: 6h
+  #interval: 6h
+  
+  # FirstInterval is the first Interval immediately after
+  # startup, to allow one soon after extended downtime.
+  # Default: 10m
+  #first_interval: 10m
+  
+  # LockDuration limits how long the sweeper may hold the exclusive write
+  # lock at one time. This effectively controls the maximum latency spike
+  # due to the sweeper for API calls that update the LMDB.
+  # This is not a hard quota, the sweeper may overrun it slightly.
+  # Default: 50ms
+  #lock_duration: 50ms
+  
+  # ReleaseDuration determines how long the sweeper must sleep before it
+  # is allowed to reacquire the exclusive write lock.
+  # If this is equal to LockDuration, it means that the sweeper can hold the
+  # LMDB at most half the time.
+  # Do not set this too high, as every sweep cycle will record a write
+  # transaction that can trigger a snapshot generation scan. It is best
+  # to get it over with in a short total sweep time.
+  # Default: 50ms
+  #release_duration: 50ms
+
+
 # Storage configures where LS stores its snapshots
 storage:
   # For the available backend types and options, please

--- a/example.yaml
+++ b/example.yaml
@@ -179,6 +179,7 @@ sweeper:
   # It is DISABLED by default, because of the important consistency
   # considerations that depend on the kind of deployment.
   # When disabled, the deleted entries will never actually be removed.
+  # Stats are only available when the sweeper is enabled.
   #enabled: false
   
   # RetentionDays is the number of DAYS of retention. Unlike in most

--- a/example.yaml
+++ b/example.yaml
@@ -219,6 +219,13 @@ sweeper:
   # Default: 50ms
   #release_duration: 50ms
 
+  # RetentionLoadCutoffDuration is the time interval close to the RetentionDays
+  # limit where we will not load deletion markers from remote snapshots,
+  # because they would soon be eligible for removal by the sweeper anyway.
+  # Only set this if you understand the implications.
+  # Default: 1% of the duration corresponding to the retention_days setting.
+  #retention_load_cutoff_duration: 0
+
 
 # Storage configures where LS stores its snapshots
 storage:

--- a/lmdbenv/limitscanner/scanner.go
+++ b/lmdbenv/limitscanner/scanner.go
@@ -1,0 +1,139 @@
+package limitscanner
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdbscan"
+)
+
+// ErrLimitReached is returned when the LimitScanner reaches the configured limit
+var ErrLimitReached = errors.New("limit reached")
+
+func NewLimitScanner(opt Options) (*LimitScanner, error) {
+	if opt.Txn == nil {
+		panic("limit scanner requires Options.Txn")
+	}
+	if opt.DBI == 0 {
+		panic("limit scanner requires Options.DBI")
+	}
+	if opt.LimitDurationCheckEvery <= 0 {
+		opt.LimitDurationCheckEvery = LimitDurationCheckEveryDefault
+	}
+	ls := &LimitScanner{
+		opt: opt,
+		sc:  lmdbscan.New(opt.Txn, opt.DBI),
+	}
+	if opt.LimitDuration > 0 {
+		ls.deadline = time.Now().Add(opt.LimitDuration)
+	}
+	return ls, nil
+}
+
+// LimitDurationCheckEveryDefault determines every how many records we check
+// if we exceeded LimitDuration.
+// This default of 1000 corresponds to around 1ms of scan time on most systems,
+// determining the granularity of our duration checks.
+const LimitDurationCheckEveryDefault = 1000
+
+type Options struct {
+	// Txn  and DBI for the scan
+	Txn *lmdb.Txn
+	DBI lmdb.DBI
+
+	// Limits imposed
+	LimitRecords            int
+	LimitDuration           time.Duration
+	LimitDurationCheckEvery int
+
+	// Last record previously scanned
+	Last LimitCursor
+}
+
+type LimitCursor struct {
+	key []byte
+	val []byte
+}
+
+func (c LimitCursor) IsZero() bool {
+	return c.key == nil && c.val == nil
+}
+
+// LimitScanner allows iteration over chunks of the LMDB for processing.
+// The chunk size can either be given as a number or as a time limit.
+type LimitScanner struct {
+	opt      Options
+	sc       *lmdbscan.Scanner
+	count    int
+	deadline time.Time
+	err      error
+}
+
+func (s *LimitScanner) Scan() bool {
+	if s.err != nil {
+		return false
+	}
+
+	if s.count == 0 && !s.opt.Last.IsZero() {
+		// Set initial position.
+		// If the entry still exists, it will be the first one (basically
+		// rescanning the last entry). If it is gone, we will start from the
+		// next one after that.
+		//s.sc.SetNext(s.opt.Last.key, s.opt.Last.val, lmdb.SetRange, lmdb.Next)
+		s.sc.Set(s.opt.Last.key, s.opt.Last.val, lmdb.SetRange)
+		if bytes.Equal(s.Key(), s.opt.Last.key) && bytes.Equal(s.Val(), s.opt.Last.val) {
+			// Advance one
+			s.sc.Set(nil, nil, lmdb.Next)
+		}
+	}
+
+	// Check number-of-records limit
+	if s.opt.LimitRecords > 0 && s.count >= s.opt.LimitRecords {
+		s.err = ErrLimitReached
+		return false
+	}
+
+	// Check time limit
+	checkEvery := s.opt.LimitDurationCheckEvery
+	if checkEvery > 0 && s.count > 0 && s.count%checkEvery == 0 && !s.deadline.IsZero() {
+		if time.Now().After(s.deadline) {
+			s.err = ErrLimitReached
+			return false
+		}
+	}
+
+	s.count++
+	return s.sc.Scan()
+}
+
+func (s *LimitScanner) Last() LimitCursor {
+	return LimitCursor{
+		key: s.Key(),
+		val: s.Val(),
+	}
+}
+
+func (s *LimitScanner) Cursor() *lmdb.Cursor {
+	return s.sc.Cursor()
+}
+
+func (s *LimitScanner) Key() []byte {
+	return s.sc.Key()
+}
+
+func (s *LimitScanner) Val() []byte {
+	return s.sc.Val()
+}
+
+func (s *LimitScanner) Err() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.sc.Err()
+}
+
+func (s *LimitScanner) Close() {
+	s.sc.Close()
+}

--- a/lmdbenv/limitscanner/scanner_test.go
+++ b/lmdbenv/limitscanner/scanner_test.go
@@ -1,0 +1,202 @@
+package limitscanner
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PowerDNS/lightningstream/lmdbenv"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitScanner(t *testing.T) {
+	err := lmdbenv.TestEnv(func(env *lmdb.Env) error {
+		var dbi lmdb.DBI
+
+		// Init
+		err := env.Update(func(txn *lmdb.Txn) error {
+			var err error
+			dbi, err = txn.OpenDBI("test", lmdb.Create)
+			require.NoError(t, err)
+
+			for i := 1; i <= 250; i++ {
+				key := fmt.Sprintf("key-%05d", i)
+				val := fmt.Sprintf("val-%05d", i)
+				err := txn.Put(dbi, []byte(key), []byte(val), 0)
+				require.NoError(t, err)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		var last LimitCursor
+		t.Run("limited-scan", func(t *testing.T) {
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:          txn,
+					DBI:          dbi,
+					LimitRecords: 100,
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				assert.Equal(t, 100, count)
+
+				last = ls.Last()
+				assert.Equal(t, "key-00100", string(last.key))
+				assert.Equal(t, "val-00100", string(last.val))
+
+				return ls.Err()
+			})
+			require.True(t, errors.Is(err, ErrLimitReached), "expected ErrLimitReached")
+		})
+
+		t.Run("limited-scan-continued", func(t *testing.T) {
+			// Limited scan - continue
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:          txn,
+					DBI:          dbi,
+					LimitRecords: 100,
+					Last:         last, // Note this added cursor
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				assert.Equal(t, 100, count)
+
+				last = ls.Last()
+				assert.Equal(t, "key-00200", string(last.key))
+				assert.Equal(t, "val-00200", string(last.val))
+
+				return ls.Err()
+			})
+			require.True(t, errors.Is(err, ErrLimitReached), "expected ErrLimitReached")
+		})
+
+		t.Run("limited-scan-continued-deleted", func(t *testing.T) {
+			// Limited scan - continue when the last entry has been deleted
+			err = env.Update(func(txn *lmdb.Txn) error {
+				return txn.Del(dbi, last.key, last.val)
+			})
+			require.NoError(t, err)
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:          txn,
+					DBI:          dbi,
+					LimitRecords: 10,
+					Last:         last,
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				assert.Equal(t, 10, count)
+
+				last = ls.Last()
+				assert.Equal(t, "key-00210", string(last.key))
+				assert.Equal(t, "val-00210", string(last.val))
+
+				return ls.Err()
+			})
+			require.True(t, errors.Is(err, ErrLimitReached), "expected ErrLimitReached")
+		})
+
+		t.Run("limited-scan-final", func(t *testing.T) {
+			// Limited scan - final chunk of 40
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:          txn,
+					DBI:          dbi,
+					LimitRecords: 100,
+					Last:         last,
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				assert.Equal(t, 40, count)
+
+				last = ls.Last()
+				assert.Nil(t, last.key)
+				assert.Nil(t, last.val)
+
+				return ls.Err()
+			})
+			require.NoError(t, err)
+		})
+
+		t.Run("limited-by-time", func(t *testing.T) {
+			// Rescan limited by time
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:                     txn,
+					DBI:                     dbi,
+					LimitDuration:           time.Nanosecond, // very short
+					LimitDurationCheckEvery: 50,              // check time every 50 records
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				// Because we check the time every 50 records, we will fetch 50
+				// before we realize we passed the short deadline.
+				assert.Equal(t, 50, count)
+
+				last = ls.Last()
+				assert.Equal(t, "key-00050", string(last.key))
+				assert.Equal(t, "val-00050", string(last.val))
+
+				return ls.Err()
+			})
+			require.True(t, errors.Is(err, ErrLimitReached), "expected ErrLimitReached")
+		})
+
+		t.Run("limited-by-plenty-of-time", func(t *testing.T) {
+			// Rescan limited by time, but with plenty of time
+			err = env.View(func(txn *lmdb.Txn) error {
+				ls, err := NewLimitScanner(Options{
+					Txn:                     txn,
+					DBI:                     dbi,
+					LimitDuration:           time.Second, // an eternity
+					LimitDurationCheckEvery: 50,          // check time every 50 records
+				})
+				require.NoError(t, err)
+
+				count := 0
+				for ls.Scan() {
+					count++
+				}
+				// Now we will manage to scan all records before the deadline
+				// (note that we deleted one before)
+				assert.Equal(t, 249, count)
+
+				last = ls.Last()
+				assert.Nil(t, last.key)
+				assert.Nil(t, last.val)
+
+				return ls.Err()
+			})
+			require.NoError(t, err)
+		})
+
+		return nil
+	})
+	require.NoError(t, err)
+
+}

--- a/syncer/iterators_test.go
+++ b/syncer/iterators_test.go
@@ -1,0 +1,152 @@
+package syncer
+
+import (
+	"testing"
+
+	"github.com/PowerDNS/lightningstream/lmdbenv/header"
+	"github.com/PowerDNS/lightningstream/snapshot"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeVal(ts uint64, flags header.Flags, appVal string) []byte {
+	buf := make([]byte, header.MinHeaderSize+len(appVal))
+	header.PutBasic(buf, header.Timestamp(ts), 123, flags)
+	copy(buf[header.MinHeaderSize:], appVal)
+	return buf
+}
+
+func TestNativeIterator_Merge(t *testing.T) {
+	tt := []struct {
+		Name          string
+		KV            snapshot.KV
+		OldVal        []byte
+		Expected      []byte
+		ExpectedError bool
+	}{
+		{
+			Name: "add-new-entry",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:   nil,
+			Expected: makeVal(30, 0, "val"),
+		},
+		{
+			Name: "add-new-entry-that-is-old",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 5, // before stale cutoff, but not marked deleted
+				Flags:         0,
+			},
+			OldVal:   nil,
+			Expected: makeVal(5, 0, "val"),
+		},
+		{
+			Name: "add-new-entry-default-ts",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 0,
+				Flags:         0,
+			},
+			OldVal:   nil,
+			Expected: makeVal(42, 0, "val"),
+		},
+		{
+			Name: "db-retains-newer-entry",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:   makeVal(40, 0, "newer"),
+			Expected: makeVal(40, 0, "newer"),
+		},
+		{
+			Name: "add-deleted-entry",
+			KV: snapshot.KV{
+				Value:         nil,
+				TimestampNano: 30,
+				Flags:         uint32(header.FlagDeleted),
+			},
+			OldVal:   nil,
+			Expected: makeVal(30, header.FlagDeleted, ""),
+		},
+		{
+			Name: "skip-stale-deleted-entry",
+			KV: snapshot.KV{
+				Value:         nil,
+				TimestampNano: 5, // stale
+				Flags:         uint32(header.FlagDeleted),
+			},
+			OldVal:   nil,
+			Expected: nil,
+		},
+		{
+			Name: "conflict-lexicographic-lower",
+			KV: snapshot.KV{
+				Value:         []byte("aaa"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:   makeVal(30, 0, "bbb"),
+			Expected: makeVal(30, 0, "aaa"),
+		},
+		{
+			Name: "conflict-lexicographic-higher",
+			KV: snapshot.KV{
+				Value:         []byte("ccc"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:   makeVal(30, 0, "bbb"),
+			Expected: makeVal(30, 0, "bbb"),
+		},
+		{
+			Name: "same",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:   makeVal(30, 0, "val"),
+			Expected: makeVal(30, 0, "val"),
+		},
+		{
+			Name: "corrupt-old-value",
+			KV: snapshot.KV{
+				Value:         []byte("val"),
+				TimestampNano: 30,
+				Flags:         0,
+			},
+			OldVal:        []byte("corrupt"),
+			ExpectedError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			it := &NativeIterator{
+				DefaultTimestampNano: 42,  // used then the timestamp is zero
+				TxnID:                123, // current txnid
+				FormatVersion:        snapshot.CurrentFormatVersion,
+				DeletedCutoff:        10, // delete markers older than this are ignored
+			}
+			tc.KV.Key = []byte("key")
+			it.curKV = tc.KV
+			res, err := it.Merge(tc.OldVal)
+			if tc.ExpectedError {
+				if err == nil {
+					t.Errorf("expected error, got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+			assert.Equal(t, tc.Expected, res)
+		})
+	}
+
+}

--- a/syncer/shadow.go
+++ b/syncer/shadow.go
@@ -78,6 +78,7 @@ func (s *Syncer) mainToShadow(ctx context.Context, txn *lmdb.Txn, tsNano header.
 			dbiMsg,
 			tsNano,
 			header.TxnID(txn.ID()),
+			s.deletedCutoff(t0),
 		)
 		if err != nil {
 			return fmt.Errorf("create native iterator: %w", err)

--- a/syncer/sweeper/metrics.go
+++ b/syncer/sweeper/metrics.go
@@ -1,0 +1,51 @@
+package sweeper
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricCleanedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "lightningstream_sweeper_cleaned_total",
+			Help: "Number of stale deletion markers cleaned by the sweeper",
+		},
+		[]string{"lmdb"},
+	)
+	metricStatsAvailable = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lightningstream_sweeper_stats_available",
+			Help: "Set to 1 when the stats are available after a sweep run",
+		},
+		[]string{"lmdb"},
+	)
+	metricStatsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lightningstream_sweeper_stats_total_entries",
+			Help: "Total entries after last sweeper run, including deleted",
+		},
+		[]string{"lmdb"},
+	)
+	metricStatsDeleted = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lightningstream_sweeper_stats_deleted_entries",
+			Help: "Deleted entries after last sweeper run",
+		},
+		[]string{"lmdb"},
+	)
+	metricDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "lightningstream_sweeper_duration_seconds",
+			Help: "Summary of time taken by sweeper",
+		},
+		[]string{"lmdb"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(metricCleanedTotal)
+	prometheus.MustRegister(metricStatsAvailable)
+	prometheus.MustRegister(metricStatsTotal)
+	prometheus.MustRegister(metricStatsDeleted)
+	prometheus.MustRegister(metricDurationSummary)
+}

--- a/syncer/sweeper/stats.go
+++ b/syncer/sweeper/stats.go
@@ -1,0 +1,36 @@
+package sweeper
+
+import (
+	"math"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type stats struct {
+	nEntries  int // total number of entries (including deleted)
+	nDeleted  int // total number of entries that are still marked as deleted
+	nCleaned  int // total number of deleted entries that have been cleaned in this run
+	nTxn      int // number of transactions
+	timeTaken time.Duration
+}
+
+func (s stats) logFields() logrus.Fields {
+	return logrus.Fields{
+		"total_entries":    s.nEntries,
+		"deleted_entries":  s.nDeleted,
+		"deleted_fraction": s.deletedFraction(),
+		"cleaned_entries":  s.nCleaned,
+		"transactions":     s.nTxn,
+		"time_taken":       s.timeTaken.Round(time.Millisecond),
+	}
+}
+
+func (s stats) deletedFraction() float64 {
+	var deletedFraction float64
+	if s.nEntries > 0 {
+		deletedFraction = float64(s.nDeleted) / float64(s.nEntries)
+		deletedFraction = math.Round(deletedFraction*1000) / 1000
+	}
+	return deletedFraction
+}

--- a/syncer/sweeper/sweeper.go
+++ b/syncer/sweeper/sweeper.go
@@ -1,0 +1,179 @@
+package sweeper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PowerDNS/lightningstream/config"
+	"github.com/PowerDNS/lightningstream/lmdbenv"
+	"github.com/PowerDNS/lightningstream/lmdbenv/header"
+	"github.com/PowerDNS/lightningstream/lmdbenv/limitscanner"
+	"github.com/PowerDNS/lightningstream/syncer"
+	"github.com/PowerDNS/lightningstream/utils"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/sirupsen/logrus"
+)
+
+func New(name string, conf config.Sweeper, env *lmdb.Env, l logrus.FieldLogger, schemaTracksChanges bool) *Sweeper {
+	return &Sweeper{
+		name:                name,
+		l:                   l,
+		env:                 env,
+		conf:                conf,
+		schemaTracksChanges: schemaTracksChanges,
+	}
+}
+
+// Sweeper cleans old stale deleted entries from a single LMDB.
+// This is also known as the "tomb sweeper".
+// You need one Sweeper per LMDB.
+// Do not confuse this with the Cleaner, which cleans snapshots.
+type Sweeper struct {
+	name string
+	l    logrus.FieldLogger
+	env  *lmdb.Env
+	conf config.Sweeper
+
+	schemaTracksChanges bool // native schema?
+
+	lastStats stats // mainly for tests
+}
+
+// Run runs the sweeper according to the configured schedule.
+// It only runs when an error occurs or the context is closed.
+func (s *Sweeper) Run(ctx context.Context) error {
+	// Technically we should only start this timer after the FirstInterval,
+	// but if FirstInterval is a lot shorter than Interval, this is good enough.
+	t := time.NewTicker(s.conf.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(s.conf.FirstInterval):
+		case <-t.C:
+		}
+		err := s.sweep(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			s.l.WithError(err).Warn("Sweep failed")
+		}
+	}
+}
+
+// sweep performs a single full database sweep.
+func (s *Sweeper) sweep(ctx context.Context) error {
+	t0 := time.Now()
+
+	retention := time.Duration(s.conf.RetentionDays * float32(24*time.Hour))
+	cutoff := time.Now().Add(-retention)
+	cutoffTS := header.TimestampFromTime(cutoff)
+
+	s.l.WithField("cutoff", cutoff).Debug("Sweep started")
+	defer s.l.Debug("Sweep finished")
+
+	// Get the list of DBI names to work on.
+	// This needs to be done every time, because new DBIs may be added over time.
+	var dbiNames []string
+	err := s.env.View(func(txn *lmdb.Txn) error {
+		var err error
+		dbiNames, err = lmdbenv.ReadDBINames(txn)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Stats
+	var st stats
+
+	for _, dbiName := range dbiNames {
+		// We must not corrupt the data if a non-native schema is used for
+		// the main data. In this case we only sweep our own shadow and meta
+		// DBIs, which do use our native format.
+		if !s.schemaTracksChanges && !strings.HasPrefix(dbiName, syncer.SyncDBIPrefix) {
+			continue
+		}
+
+		l := s.l.WithField("dbi", dbiName)
+		l.Debug("Sweep DBI")
+
+		var last limitscanner.LimitCursor
+		for {
+			err := s.env.Update(func(txn *lmdb.Txn) error {
+				st.nTxn++
+
+				dbi, err := txn.OpenDBI(dbiName, 0)
+				if err != nil {
+					return err
+				}
+
+				ls, err := limitscanner.NewLimitScanner(limitscanner.Options{
+					Txn:                     txn,
+					DBI:                     dbi,
+					LimitDuration:           s.conf.LockDuration,
+					LimitDurationCheckEvery: limitscanner.LimitDurationCheckEveryDefault,
+					Last:                    last,
+				})
+				if err != nil {
+					return err // configuration error
+				}
+
+				// Actual cleaning
+				for ls.Scan() {
+					h, _, err := header.Parse(ls.Val())
+					if err != nil {
+						return fmt.Errorf("failed to parse header for key %s: %w",
+							utils.DisplayASCII(ls.Key()), err)
+					}
+					if !h.Flags.IsDeleted() {
+						// TODO: Consider keeping track of a histogram of ages,
+						//       but the standard Prometheus Observe() may be
+						//       too slow to use here.
+						st.nEntries++
+						continue
+					}
+					if h.Timestamp >= cutoffTS {
+						st.nEntries++
+						st.nDeleted++
+						continue
+					}
+					// Too old deleted entry, clean
+					st.nCleaned++
+					if err := txn.Del(dbi, ls.Key(), ls.Val()); err != nil {
+						// Should only happen if the mapsize or disk is full
+						return fmt.Errorf("failed to delete key %s: %w",
+							utils.DisplayASCII(ls.Key()), err)
+					}
+				}
+
+				last = ls.Last()
+				return ls.Err()
+			})
+			if errors.Is(err, limitscanner.ErrLimitReached) {
+				l.Debug("Sweep limit reached, continuing after pause")
+				// Give the app some room to get a write lock before continuing
+				if err := utils.SleepContext(ctx, s.conf.ReleaseDuration); err != nil {
+					return err
+				}
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("failed to sweep dbi %s: %w", dbiName, err)
+			}
+
+			// Done with this DBI
+			break
+		}
+	}
+	st.timeTaken = time.Since(t0)
+	s.lastStats = st
+	s.l.WithFields(st.logFields()).
+		Info("Sweep for stale deleted entries completed")
+	return nil
+}

--- a/syncer/sweeper/sweeper.go
+++ b/syncer/sweeper/sweeper.go
@@ -177,6 +177,11 @@ func (s *Sweeper) sweep(ctx context.Context) error {
 	}
 	st.timeTaken = time.Since(t0)
 	s.lastStats = st
+	metricCleanedTotal.WithLabelValues(s.name).Add(float64(st.nCleaned))
+	metricStatsTotal.WithLabelValues(s.name).Set(float64(st.nEntries))
+	metricStatsDeleted.WithLabelValues(s.name).Set(float64(st.nDeleted))
+	metricStatsAvailable.WithLabelValues(s.name).Set(1)
+	metricDurationSummary.WithLabelValues(s.name).Observe(st.timeTaken.Seconds())
 	s.l.WithFields(st.logFields()).
 		Info("Sweep for stale deleted entries completed")
 	return nil

--- a/syncer/sweeper/sweeper_test.go
+++ b/syncer/sweeper/sweeper_test.go
@@ -1,0 +1,164 @@
+package sweeper
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PowerDNS/lightningstream/config"
+	"github.com/PowerDNS/lightningstream/lmdbenv"
+	"github.com/PowerDNS/lightningstream/lmdbenv/header"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSweeper(t *testing.T) {
+	conf := config.Sweeper{
+		Enabled:         true,
+		RetentionDays:   2,
+		Interval:        time.Second,
+		FirstInterval:   0,
+		LockDuration:    time.Second,
+		ReleaseDuration: 0,
+	}
+
+	l, _ := test.NewNullLogger()
+
+	err := lmdbenv.TestEnv(func(env *lmdb.Env) error {
+		sweeper := New("test", conf, env, l, true)
+
+		t.Run("empty-lmdb", func(t *testing.T) {
+			// Completely empty database sweep
+			assert.NoError(t, sweeper.sweep(t.Context()))
+		})
+
+		createDBI := func(name string) lmdb.DBI {
+			var dbi lmdb.DBI
+			err := env.Update(func(txn *lmdb.Txn) error {
+				var err error
+				dbi, err = txn.CreateDBI("test1")
+				return err
+			})
+			assert.NoError(t, err)
+			return dbi
+		}
+
+		t.Run("empty-dbi", func(t *testing.T) {
+			// Empty DBI sweep
+			_ = createDBI("empty")
+			assert.NoError(t, sweeper.sweep(t.Context()))
+		})
+
+		t.Run("mix", func(t *testing.T) {
+			now := time.Now()
+			past := now.Add(-50 * time.Hour) // longer than RetentionDays=2
+			nowTS := header.TimestampFromTime(now)
+			pastTS := header.TimestampFromTime(past)
+
+			mix := createDBI("mix")
+
+			assert.NoError(t, env.Update(func(txn *lmdb.Txn) error {
+				for i := 0; i < 3000; i++ {
+					key := []byte(fmt.Sprintf("key-%08d", i))
+					val := make([]byte, header.MinHeaderSize)
+					switch i % 3 {
+					case 0:
+						// Normal entry, not deleted
+						header.PutBasic(val, pastTS, 1, 0)
+					case 1:
+						// Recently deleted entry
+						header.PutBasic(val, nowTS, 1, header.FlagDeleted)
+					case 2:
+						// Deleted longer time ago
+						header.PutBasic(val, pastTS, 1, header.FlagDeleted)
+					}
+					assert.NoError(t, txn.Put(mix, key, val, 0))
+				}
+				return nil
+			}))
+
+			assert.NoError(t, sweeper.sweep(t.Context()))
+			assert.Equal(t, 2000, sweeper.lastStats.nEntries)
+			assert.Equal(t, 1000, sweeper.lastStats.nDeleted)
+			assert.Equal(t, 1000, sweeper.lastStats.nCleaned)
+			assert.Equal(t, 0.5, sweeper.lastStats.deletedFraction())
+			t.Logf("Cleaning 3000 entries took %s", sweeper.lastStats.timeTaken)
+		})
+
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func BenchmarkSweeper(b *testing.B) {
+	// This benchmark creates b.N entries and sweeps them.
+	// Here 1/3 of the entries will be cleaned.
+
+	// TODO: This may create a large LMDB and fail at a certain N due to mapsize.
+	//       Find a better way?
+
+	conf := config.Sweeper{
+		Enabled:         true,
+		RetentionDays:   2,
+		Interval:        time.Second,
+		FirstInterval:   0,
+		LockDuration:    100 * time.Millisecond, // Forces split operation
+		ReleaseDuration: 0,
+	}
+
+	l, _ := test.NewNullLogger()
+
+	err := lmdbenv.TestEnv(func(env *lmdb.Env) error {
+		sweeper := New("test", conf, env, l, true)
+
+		createDBI := func(name string) lmdb.DBI {
+			var dbi lmdb.DBI
+			err := env.Update(func(txn *lmdb.Txn) error {
+				var err error
+				dbi, err = txn.CreateDBI("test1")
+				return err
+			})
+			assert.NoError(b, err)
+			return dbi
+		}
+
+		now := time.Now()
+		past := now.Add(-50 * time.Hour) // longer than RetentionDays=2
+		nowTS := header.TimestampFromTime(now)
+		pastTS := header.TimestampFromTime(past)
+
+		mix := createDBI("bench")
+
+		assert.NoError(b, env.Update(func(txn *lmdb.Txn) error {
+			for i := 0; i < b.N; i++ {
+				key := []byte(fmt.Sprintf("key-%08d", i))
+				val := make([]byte, header.MinHeaderSize)
+				switch i % 3 {
+				case 0:
+					// Normal entry, not deleted
+					header.PutBasic(val, pastTS, 1, 0)
+				case 1:
+					// Recently deleted entry
+					header.PutBasic(val, nowTS, 1, header.FlagDeleted)
+				case 2:
+					// Deleted longer time ago
+					header.PutBasic(val, pastTS, 1, header.FlagDeleted)
+				}
+				assert.NoError(b, txn.Put(mix, key, val, 0))
+			}
+			return nil
+		}))
+
+		// Actual benchmark
+		b.ReportAllocs()
+		b.ResetTimer()
+		err := sweeper.sweep(b.Context())
+		b.StopTimer()
+		// This is the most interesting metric
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "entries/s")
+
+		return err
+	})
+	assert.NoError(b, err)
+}

--- a/syncer/sync.go
+++ b/syncer/sync.go
@@ -447,6 +447,7 @@ func (s *Syncer) LoadOnce(ctx context.Context, env *lmdb.Env, instance string, u
 				dbiMsg,
 				0, // no default timestamp
 				header.TxnID(txn.ID()),
+				s.deletedCutoff(t0),
 			)
 			if err != nil {
 				return fmt.Errorf("create native iterator: %w", err)

--- a/syncer/utils.go
+++ b/syncer/utils.go
@@ -265,11 +265,10 @@ func (s *Syncer) deletedCutoff(now time.Time) header.Timestamp {
 	if !s.c.Sweeper.Enabled {
 		return 0
 	}
-	// The RetentionDuration is decreased by 1% to not add new deletion markers
+	// The RetentionDuration is decreased to not add new deletion markers
 	// that would go stale very soon, and to correct for the 'now' timestamp
 	// actually being slightly in the past when the whole operation was started.
-	retention := s.c.Sweeper.RetentionDuration()
-	retention -= retention / 100 // subtract 1%
+	retention := s.c.Sweeper.RetentionDurationMinusCutoff()
 	cutoff := now.Add(-retention)
 	return header.TimestampFromTime(cutoff)
 }

--- a/syncer/utils.go
+++ b/syncer/utils.go
@@ -256,3 +256,20 @@ func (s *Syncer) registerCollector(env *lmdb.Env) {
 	lmdbCollector.EnableSmaps(s.c.LMDBScrapeSmaps)
 	lmdbCollector.AddTarget(s.name, nil, env)
 }
+
+// deletedCutoff is the cutoff for stale deleted markers to not re-add them
+// after the Sweeper has cleaned them.
+// If the sweeper is disabled, this returns 0, which will never filter out
+// records.
+func (s *Syncer) deletedCutoff(now time.Time) header.Timestamp {
+	if !s.c.Sweeper.Enabled {
+		return 0
+	}
+	// The RetentionDuration is decreased by 1% to not add new deletion markers
+	// that would go stale very soon, and to correct for the 'now' timestamp
+	// actually being slightly in the past when the whole operation was started.
+	retention := s.c.Sweeper.RetentionDuration()
+	retention -= retention / 100 // subtract 1%
+	cutoff := now.Add(-retention)
+	return header.TimestampFromTime(cutoff)
+}


### PR DESCRIPTION
The 'tombsweeper' (sweeper in short) cleans old stale delete markers from the LMDB.

Closes #81

**WARNING**: This is DISABLED by default, because enabling this functionality requires careful consideration. When enabled, you MUST make sure that no instance that has been offline for longer than the sweeper `retention_days` will ever reconnect. If this does happen, old entries that have been deleted may be resurrected causing anything from undesired results to database state corruption.  Be especially careful about development or testing systems that only come online occasionally.

For small personal installations with infrequent changes, it is probably better NOT to enable this functionality, and accept that deleted entries accumulate over time. Only consider this you have frequent updates and deletion markers would actually become a problem over time. And in that case, be very conservative with the `retention_days` setting, the longer the better.

Progress

- [x] Working Sweeper with incremental sweep support
- [x] Configuration
- [x] Filter stale entries when loading snapshots
- [x] Add metrics to track deleted entries

Likely later in a different PR:

- [ ] Document this part of LS


New YAML example config section:

```yaml

# Sweeper settings for the LMDB sweeper that removed deleted entries after
# a while, also known as the "tomb sweeper".
#
# The key consideration for these settings is how long instance can be
# expected to be disconnected from the storage (out of sync) before
# rejoining. If the retention interval is set too low, old records that
# have been removed during the downtime can reappear, which can cause
# major issues.
#
# When picking a value, also take into account development, testing and
# migration systems that only occasionally come online.
#
sweeper:
  # Enabled controls if the sweeper is enabled.
  # It is DISABLED by default, because of the important consistency
  # considerations that depend on the kind of deployment.
  # When disabled, the deleted entries will never actually be removed.
  # Stats are only available when the sweeper is enabled.
  #enabled: false

  # RetentionDays is the number of DAYS of retention. Unlike in most
  # other places, this is specified in number of days instead of Duration
  # because of the expected length of this.
  # This is a float, so it is possible to use periods shorter than one day,
  # but this is rarely a good idea. Best to set this as high as possible.
  # Default: 370 (days, intentionally on the safe side)
  #retention_days: 370

  # Interval is the interval between sweeps of the whole database to enforce
  # RetentionDays.
  # As a guideline, on a fast server sweeping 1 million records takes
  # about 1 second.
  # Default: 6h
  #interval: 6h

  # FirstInterval is the first Interval immediately after
  # startup, to allow one soon after extended downtime.
  # Default: 10m
  #first_interval: 10m

  # LockDuration limits how long the sweeper may hold the exclusive write
  # lock at one time. This effectively controls the maximum latency spike
  # due to the sweeper for API calls that update the LMDB.
  # This is not a hard quota, the sweeper may overrun it slightly.
  # Default: 50ms
  #lock_duration: 50ms

  # ReleaseDuration determines how long the sweeper must sleep before it
  # is allowed to reacquire the exclusive write lock.
  # If this is equal to LockDuration, it means that the sweeper can hold the
  # LMDB at most half the time.
  # Do not set this too high, as every sweep cycle will record a write
  # transaction that can trigger a snapshot generation scan. It is best
  # to get it over with in a short total sweep time.
  # Default: 50ms
  #release_duration: 50ms
```

New metrics:

```
# HELP lightningstream_sweeper_cleaned_total Number of stale deletion markers cleaned by the sweeper
# TYPE lightningstream_sweeper_cleaned_total counter
lightningstream_sweeper_cleaned_total{lmdb="main"} 0
lightningstream_sweeper_cleaned_total{lmdb="shard"} 0
# HELP lightningstream_sweeper_duration_seconds Summary of time taken by sweeper
# TYPE lightningstream_sweeper_duration_seconds summary
lightningstream_sweeper_duration_seconds_sum{lmdb="main"} 0.000113072
lightningstream_sweeper_duration_seconds_count{lmdb="main"} 1
lightningstream_sweeper_duration_seconds_sum{lmdb="shard"} 4.4089e-05
lightningstream_sweeper_duration_seconds_count{lmdb="shard"} 1
# HELP lightningstream_sweeper_stats_available Set to 1 when the stats are available after a sweep run
# TYPE lightningstream_sweeper_stats_available gauge
lightningstream_sweeper_stats_available{lmdb="main"} 1
lightningstream_sweeper_stats_available{lmdb="shard"} 1
# HELP lightningstream_sweeper_stats_deleted_entries Deleted entries after last sweeper run
# TYPE lightningstream_sweeper_stats_deleted_entries gauge
lightningstream_sweeper_stats_deleted_entries{lmdb="main"} 0
lightningstream_sweeper_stats_deleted_entries{lmdb="shard"} 0
# HELP lightningstream_sweeper_stats_total_entries Total entries after last sweeper run, including deleted
# TYPE lightningstream_sweeper_stats_total_entries gauge
lightningstream_sweeper_stats_total_entries{lmdb="main"} 9
lightningstream_sweeper_stats_total_entries{lmdb="shard"} 5
```
