### PR TITLE
Backport to 0.4: use debian bookworm for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builder
 # Note: Not using Alpine, because of CGo deps
-FROM golang:1.19-buster as builder
+FROM golang:1.24-bookworm AS builder
 ENV GOBIN=/usr/local/bin
 ARG GOPROXY=
 
@@ -18,7 +18,7 @@ RUN echo "GOFLAGS=$GOFLAGS"; go install ./cmd/...
 
 # Dist
 # Note: When using Alpine, ls prevents auth api from correctly functioning (most likely some locking issue)
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN ulimit -n 2000 \
         && apt-get update \


### PR DESCRIPTION
Cherry-picked from 8b346490bac59d8121d5a7998a6aa40445327242