### PR TITLE
NameInfo: fix BaseName empty

### DIFF
--- a/snapshot/name.go
+++ b/snapshot/name.go
@@ -66,6 +66,7 @@ func ParseName(name string) (NameInfo, error) {
 		return empty, fmt.Errorf("invalid name: no dot: %s", name)
 	}
 	ni.FullName = name
+	ni.BaseName = basename
 	kind, known := registeredExtensions[ext]
 	if !known {
 		return empty, fmt.Errorf("unknown extension: %s", name)

--- a/snapshot/name_test.go
+++ b/snapshot/name_test.go
@@ -20,6 +20,7 @@ func TestParseName(t *testing.T) {
 			Name("db1", "inst1", "G1", ts),
 			NameInfo{
 				FullName:        "db1__inst1__20220102-030405-012345678__G1.pb.gz",
+				BaseName:        "db1__inst1__20220102-030405-012345678__G1",
 				Extension:       "pb.gz",
 				Kind:            "snapshot",
 				SyncerName:      "db1",
@@ -35,6 +36,7 @@ func TestParseName(t *testing.T) {
 			"db1__inst1__20220102-030405-012345678__G1__X123__Y456.pb.gz",
 			NameInfo{
 				FullName:        "db1__inst1__20220102-030405-012345678__G1__X123__Y456.pb.gz",
+				BaseName:        "db1__inst1__20220102-030405-012345678__G1__X123__Y456",
 				Extension:       "pb.gz",
 				Kind:            "snapshot",
 				SyncerName:      "db1",


### PR DESCRIPTION
`NameInfo.BaseName` was empty after `ParseName`.

This only affected new tests, not actual production code.
