### PR TITLE
Documentation improvements regarding pdns auth integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,6 +210,8 @@ health:
 
 This example configuration assumes a PowerDNS Authoritative server setup with native schemas, but it
 explains every available option.
+See [Lightning Stream with PowerDNS Authoritative server](pdns-auth-installation.md) for details on
+Lightning Stream integration with PowerDNS Authoritative server.
 
 ```yaml
 # This is a Lightning Stream (LS) example configuration for use with the
@@ -308,7 +310,7 @@ lmdbs:
       # that can be used for LMDB data pages and limits the file size of an
       # LMDB. Keep in mind that an LMDB file can eventually grow to its mapsize.
       # A value of 0 means 1GB when creating a new LMDB.
-      #map_size: 1GB
+      map_size: 1000MB # Match the 1000MB used in PowerDNS auth integration docs
 
       # The maximum number of named DBIs within the LMDB. 0 means default.
       #max_dbs: 64
@@ -367,6 +369,8 @@ lmdbs:
     options:
       no_subdir: true
       create: true
+      map_size: 1000MB
+    schema_tracks_changes: true
 
     # Example use to create new LMDBs from old snapshots of older PDNS Auth
     # 4.7 LMDBs. This is not be needed for any new deployment with PDNS Auth

--- a/docs/configuration.template.md
+++ b/docs/configuration.template.md
@@ -205,6 +205,8 @@ health:
 
 This example configuration assumes a PowerDNS Authoritative server setup with native schemas, but it
 explains every available option.
+See [Lightning Stream with PowerDNS Authoritative server](pdns-auth-installation.md) for details on
+Lightning Stream integration with PowerDNS Authoritative server.
 
 ```yaml
 __CONFIG__

--- a/docs/pdns-auth-installation.md
+++ b/docs/pdns-auth-installation.md
@@ -48,11 +48,8 @@ lmdb-filename=/path/to/lmdb
 # Note that this cannot safely be changed later!
 lmdb-shards=1
 
-# This MUST be enabled to safely handle multiple writers
-lmdb-random-ids=yes
-
-# This MUST be enabled to track and propagate deletes
-lmdb-flag-deleted=yes
+# Ensure Lightning Stream compatible LMDB parameters
+lmdb-lightning-stream=yes
 
 # You may want a lower number than 16000 MB, which is the default on 64 bit systems.
 lmdb-map-size=1000

--- a/example.yaml
+++ b/example.yaml
@@ -94,7 +94,7 @@ lmdbs:
       # that can be used for LMDB data pages and limits the file size of an
       # LMDB. Keep in mind that an LMDB file can eventually grow to its mapsize.
       # A value of 0 means 1GB when creating a new LMDB.
-      #map_size: 1GB
+      map_size: 1000MB # Match the 1000MB used in PowerDNS auth integration docs
 
       # The maximum number of named DBIs within the LMDB. 0 means default.
       #max_dbs: 64
@@ -153,6 +153,8 @@ lmdbs:
     options:
       no_subdir: true
       create: true
+      map_size: 1000MB
+    schema_tracks_changes: true
 
     # Example use to create new LMDBs from old snapshots of older PDNS Auth
     # 4.7 LMDBs. This is not be needed for any new deployment with PDNS Auth

--- a/example.yaml
+++ b/example.yaml
@@ -94,7 +94,8 @@ lmdbs:
       # that can be used for LMDB data pages and limits the file size of an
       # LMDB. Keep in mind that an LMDB file can eventually grow to its mapsize.
       # A value of 0 means 1GB when creating a new LMDB.
-      #map_size: 1GB
+      #map_size: 1GB # Default of 1024MB
+      map_size: 1000MB # Match the 1000MB used in PowerDNS auth integration docs
 
       # The maximum number of named DBIs within the LMDB. 0 means default.
       #max_dbs: 64
@@ -153,6 +154,8 @@ lmdbs:
     options:
       no_subdir: true
       create: true
+      map_size: 1000MB
+    schema_tracks_changes: true
 
     # Example use to create new LMDBs from old snapshots of older PDNS Auth
     # 4.7 LMDBs. This is not be needed for any new deployment with PDNS Auth


### PR DESCRIPTION
This updates documentation and `example.yaml` to improve clarity and remove inconsistencies with other documentation.

Fixes these inconsistencies in `example.yaml`: 
* Missing `schema_tracks_changes: true` for `shard`
* Used 1024MB map size instead of the 1000MB used in the [powerdns integration docs](https://doc.powerdns.com/lightningstream/latest/pdns-auth-installation/index.html#configuring-lightning-stream)

Adds a link in `docs/configuration.template.md` above the annotated example configuration (supposedly for powerdns auth) referring directly to the [powerdns integration docs](https://doc.powerdns.com/lightningstream/latest/pdns-auth-installation/index.html) for details on that subject.

Changes `docs/pdns-auth-installation.md` to use `lmdb-lightning-stream=yes` as documented in [powerdns auth docs](https://doc.powerdns.com/authoritative/backends/lmdb.html#lmdb-lightning-stream).