### PR TITLE
Add a `checkconfig` command

### DIFF
--- a/cmd/lightningstream/commands/checkconfig.go
+++ b/cmd/lightningstream/commands/checkconfig.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var checkConfigCmd = &cobra.Command{
+	Use:   "checkconfig",
+	Short: "Check that the configuration is valid",
+	Run: func(cmd *cobra.Command, args []string) {
+		logrus.Info("Config is valid")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(checkConfigCmd)
+}

--- a/cmd/lightningstream/commands/root.go
+++ b/cmd/lightningstream/commands/root.go
@@ -85,8 +85,15 @@ var rootCmd = &cobra.Command{
 		conf.Version = mainVersion
 		// Also check at this stage. A config must always be valid, even if you
 		// later override some items.
-		if err := conf.Check(); err != nil {
-			logrus.Fatalf("Config file error: %v", err)
+		if errs := conf.Check(); len(errs) > 0 {
+			for _, e := range errs {
+				logrus.Errorf("%v", e)
+			}
+			var maybeS string
+			if len(errs) > 1 {
+				maybeS = "s"
+			}
+			logrus.Fatalf("%d config file error%s, aborting", len(errs), maybeS)
 		}
 
 		if conf.Storage.RootPath != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -351,57 +351,57 @@ type Health struct {
 }
 
 // Check validates a Config instance
-func (c Config) Check() error {
+func (c Config) Check() (errs []error) {
 	if err := c.Log.Check(); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	if len(c.LMDBs) < 1 {
-		return fmt.Errorf("no LMDBs configured")
+		errs = append(errs, fmt.Errorf("no LMDBs configured"))
 	}
 	for name, l := range c.LMDBs {
 		prefix := fmt.Sprintf("lmdb %q", name)
 		if l.Path == "" {
-			return fmt.Errorf("%s: no path configured", prefix)
+			errs = append(errs, fmt.Errorf("%s: no path configured", prefix))
 		}
 		if l.Options.FileMask > 0o777 {
-			return fmt.Errorf("lmdb.options.file_mask: too large value, possible use of decimal (%d) instead of octal (%#o)",
-				l.Options.FileMask, l.Options.FileMask)
+			errs = append(errs, fmt.Errorf("lmdb.options.file_mask: too large value, possible use of decimal (%d) instead of octal (%#o)",
+				l.Options.FileMask, l.Options.FileMask))
 		}
 		if l.Options.DirMask > 0o777 {
-			return fmt.Errorf("lmdb.options.dir_mask: too large value, possible use of decimal (%d) instead of octal (%#o)",
-				l.Options.DirMask, l.Options.DirMask)
+			errs = append(errs, fmt.Errorf("lmdb.options.dir_mask: too large value, possible use of decimal (%d) instead of octal (%#o)",
+				l.Options.DirMask, l.Options.DirMask))
 		}
 		if l.SchemaTracksChanges && l.DupSortHack {
-			return fmt.Errorf("lmdb.schema_tracks_changes: cannot be used together with the dupsort_hack option")
+			errs = append(errs, fmt.Errorf("lmdb.schema_tracks_changes: cannot be used together with the dupsort_hack option"))
 		}
 	}
 	if c.HTTP.Address != "" {
 		if _, _, err := net.SplitHostPort(c.HTTP.Address); err != nil {
-			return fmt.Errorf("http.address: %v", err)
+			errs = append(errs, fmt.Errorf("http.address: %v", err))
 		}
 	}
 	if c.LMDBPollInterval < 100*time.Millisecond {
-		return fmt.Errorf("lmdb_poll_interval: too short interval")
+		errs = append(errs, fmt.Errorf("lmdb_poll_interval: too short interval"))
 	}
 	if c.StoragePollInterval < 100*time.Millisecond {
-		return fmt.Errorf("storage_poll_interval: too short interval")
+		errs = append(errs, fmt.Errorf("storage_poll_interval: too short interval"))
 	}
 	if c.StorageRetryInterval < 100*time.Millisecond {
-		return fmt.Errorf("storage_retry_interval: too short interval")
+		errs = append(errs, fmt.Errorf("storage_retry_interval: too short interval"))
 	}
 	if dt := c.StorageForceSnapshotInterval; dt != 0 && dt < time.Minute {
-		return fmt.Errorf("storage_force_snapshot_interval: too short interval (minimum 1m if enabled)")
+		errs = append(errs, fmt.Errorf("storage_force_snapshot_interval: too short interval (minimum 1m if enabled)"))
 	}
 	if c.StorageRetryCount < 1 {
-		return fmt.Errorf("storage_retry_count: positive number required")
+		errs = append(errs, fmt.Errorf("storage_retry_count: positive number required"))
 	}
 	if c.MemoryDownloadedSnapshots < 1 {
-		return fmt.Errorf("memory_downloaded_snapshots: positive number required")
+		errs = append(errs, fmt.Errorf("memory_downloaded_snapshots: positive number required"))
 	}
 	if c.MemoryDecompressedSnapshots < 1 {
-		return fmt.Errorf("memory_decompressed_snapshots: positive number required")
+		errs = append(errs, fmt.Errorf("memory_decompressed_snapshots: positive number required"))
 	}
-	return nil
+	return
 }
 
 func (c Config) Clone() Config {


### PR DESCRIPTION
Add a command allowing for configuration to be checked without performing any other operations. This is useful for validating configuration changes separately, e.g. as part of config management or prior to restarting the service.

I was going to open an issue first to discuss but the implementation is so trivial that I figured I may as well do it first.
I'm not super happy about the actual command `Run` function being a no-op, but this was the least disruptive change and still means that all the validation happens in one place...

This does also alter the behavior of the configuration checking to print *all* config errors rather than just the first. IMO for a check function this behavior is right, and I think it's also more useful at "proper" run time, but very happy to revert to the previous behavior for all commands other than `checkconfig` if preferred. 

